### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    # @items = Item.order('created_at DESC')
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,14 +128,12 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-    <% if  @items.present? %>
+    <% if @items.present? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to items_path(item.id) do %>
+        <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
-          <% end %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <!--div class='sold-out'>
@@ -159,10 +157,8 @@
         <% end %>
         </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -180,8 +176,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,24 +129,27 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% if  @items.present? %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to items_path(item.id) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
+          <% end %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <!--div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div-->
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -154,7 +157,8 @@
           </div>
         </div>
         <% end %>
-      </li>
+        </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,7 +10,7 @@
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
-        <!span>Sold Out!!</span>
+        <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,7 +10,7 @@
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
-        <span>Sold Out!!</span>
+        <!span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "items#index"
-  resources :items 
+  resources :items, only: [:new, :create, :index]
 end


### PR DESCRIPTION
# what
・出品されている商品の「画像・商品名・価格・配送料の負担」の4つの情報を表示
・出品された日時が新しい順に商品を表示

# why
商品一覧表示機能実装のため


GyazoのURLを添付いたします。

商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/99d31b7871215da64ae833f67b440c18

商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://gyazo.com/4c4e39a07bd65effb99e92033a07c639