### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,24 +24,12 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    unless current_user == @item.user
-      redirect_to root_path
-    end  
   end
 
   def update
-    if @item.update(item_params)
-      redirect_to item_path(@item)
-    else
-      render :edit
-    end
   end
 
   def destroy
-    if current_user == @item.user
-      @item.destroy
-    end
-      redirect_to root_path
   end
 
   def set_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,10 @@
 class ItemsController < ApplicationController
 
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
-    @items = Item.all.order('created_at DESC')
+    @items = Item.order('created_at DESC')
   end
 
   def new
@@ -16,7 +17,35 @@ class ItemsController < ApplicationController
       redirect_to root_path
     else
       render :new
+    end    
+  end
+
+  def show
+  end
+
+  def edit
+    unless current_user == @item.user
+      redirect_to root_path
+    end  
+  end
+
+  def update
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit
     end
+  end
+
+  def destroy
+    if current_user == @item.user
+      @item.destroy
+    end
+      redirect_to root_path
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
   private 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -18,7 +18,6 @@
     </div>
   </div>
   <%# /画面上部の「人生を変えるフリマアプリ」帯部分  %>
-
   <%# FURIMAが選ばれる3つの理由部分 %>
   <div class='select-reason-contents'>
     <h2 class='title'>
@@ -61,7 +60,6 @@
     </ul>
   </div>
   <%# /FURIMAが選ばれる3つの理由部分 %>
-
   <%# 画面中央の「会員数日本一位」帯部分 %>
   <div class='ad-contents'>
     <h2 class='ad-title'>
@@ -82,7 +80,6 @@
     </div>
   </div>
   <%# /画面中央の「会員数日本一位」帯部分 %>
-
   <%# FURIMAの特徴 %>
   <div class='feature-contents'>
     <h2 class='title'>
@@ -119,7 +116,6 @@
     </ul>
   </div>
   <%# /FURIMAの特徴 %>
-
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
@@ -131,10 +127,9 @@
     <% if @items.present? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
-
           <%# 商品が売れていればsold outを表示しましょう %>
           <!--div class='sold-out'>
             <span>Sold Out!!</span>
@@ -157,7 +152,6 @@
         <% end %>
         </li>
       <% end %>
-
       <% else %>
       <li class='list'>
         <%= link_to '#' do %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -99,9 +99,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,11 +25,11 @@
 
     <% if user_signed_in? %>
     <% if current_user.id == @item.user_id %>
-      <%#= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
       <!p class='or-text'>or</p>
-      <%#= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
-    <%# else %>
-      <%#= link_to '購入画面に進む', item_path(@item.id), class:"item-red-btn"%>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% else %>
+      <%= link_to '購入画面に進む', "#", class:"item-red-btn"%>
     <% end %>
   <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
@@ -25,11 +25,11 @@
 
     <% if user_signed_in? %>
     <% if current_user.id == @item.user_id %>
-      <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
-      <p class='or-text'>or</p>
-      <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
-    <% else %>
-      <%= link_to '購入画面に進む', item_path(@item.id), class:"item-red-btn"%>
+      <%#= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
+      <!p class='or-text'>or</p>
+      <%#= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+    <%# else %>
+      <%#= link_to '購入画面に進む', item_path(@item.id), class:"item-red-btn"%>
     <% end %>
   <% end %>
 
@@ -100,7 +100,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,34 +7,31 @@
       <%= "商品名" %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
+      <!--div class="sold-out">
         <span>Sold Out!!</span>
-      </div>
+      </div-->
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_cost.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? %>
+    <% if current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+    <% else %>
+      <%= link_to '購入画面に進む', item_path(@item.id), class:"item-red-btn"%>
+    <% end %>
+  <% end %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -63,7 +60,7 @@
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.shipping_date.name%></td>
+          <td class="detail-value"><%= @item.delivery_date.name%></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "items#index"
-  resources :items, only: [:new, :create, :index]
+  resources :items
 end


### PR DESCRIPTION
# what
・ 商品一覧ページにて商品情報をクリックすると該当商品の商品詳細画面へ遷移するよう実装
・ 商品詳細画面で、その商品の情報や画像を表示されるよう実装
・ ユーザーによって表示されるボタンが変化するよう条件分岐する

# why
商品詳細表示機能実装のため


GyazoのURLを添付いたします。

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/833609a370fcb1f3870b77d071e5aeb8

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/4cbc0d6edd5469fd86a03433e61ac8e1

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
 ➡︎商品購入機能は未実装のため、動画はありません。

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/e7ffb28627c7ff0ef360c91c2d44f402
https://gyazo.com/3212ae115aa1c338e4b8ec8234919e05
https://gyazo.com/34d38ad32ab67ff3a2fdf5a7c1ff9eb4


